### PR TITLE
Add reading list for Socratic Seminar #9. Minor updates to README and home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Boston BitDevs
+This repo has been forked from [SF Bitcoin Devs](https://github.com/sfbitcoindevs/sfbitcoindevs) and follows guidance from NYC BitDevs on [Running a Great Socratic Seminar](https://bitdevs.org/running-a-great-socratic-seminar/).
 
 ## Socratic Reading List Sources
 
@@ -14,5 +15,20 @@ These are good places to start when compiling the reading List:
 - Triangle BitDevs - https://trianglebitdevs.org/
 - BitDevs NYC - https://bitdevs.org/
 - Austin BitDevs - https://austinbitdevs.com/
+- SF Bitcoin Devs - https://sfbitcoindevs.org/
 
 [Music to listen to while compiling.](https://www.door.link/)
+
+## Running locally
+
+If you don't have rust installed yet, get it [here](https://www.rust-lang.org/tools/install).
+
+This project uses [just](https://github.com/casey/just), which can be installed with:
+
+`cargo install just`
+
+After that, you can run things locally with:
+
+`just serve`
+
+See the `justfile` for more commands.

--- a/bin/check-links
+++ b/bin/check-links
@@ -4,7 +4,7 @@ set -euo pipefail
 links=(
   feed.xml
   posts
-  socratic/2022/09/08/socratic-1.html
+  socratic/2022/09/08/socratic-09.html
 )
 
 for link in ${links[@]}; do

--- a/content/socratic-09.md
+++ b/content/socratic-09.md
@@ -1,0 +1,50 @@
++++
+title = "Socratic Seminar 9"
+date = 2022-09-08
+aliases = ["socratic/2022/09/08/socratic-09.html"]
++++
+
+Housekeeping and Welcome!
+--------
+
+It's been over 2.5 years since the last Boston BitDevs meetup. We've got a lot of ground to make up for! 
+
+You may be wondering where the reading lists for Socratic Seminars 1-8 are. Those can be found in the [Past Events](https://www.meetup.com/boston-bitdevs/events/past/) section of the Meetup page.
+
+- [What is a Socratic Seminar?](https://bitdevs.org/about#socratic-seminars)
+- Questions are encouraged, including basic ones! Suggest topics for the next Socratic Seminar [here](https://github.com/0xBEEFCAF3/bostonbitdevs/issues/new).
+- [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule): You are  free to share discussions and learnings from Boston BitDevs, but do not reveal the source of the information. Do not share the identity of any of the speakers or participants.
+
+Culture
+-------
+- [Craig Wright Defamation Case Nears](https://www.coindesk.com/policy/2022/08/25/pseudonymous-hodlonaut-very-confident-as-craig-wright-defamation-case-nears/). Hodlonaut raises over $1.2 million in defense fund.
+- ["Wright's fraud is an attack on Bitcoin"](https://np.reddit.com/r/Bitcoin/comments/ws8wfd/starting_september_12th_in_oslo_norway_hodlonaut/ikxqxoo/) by Greg Maxwell
+- [defendingbtc.com](https://www.defendingbtc.com/)
+
+Bitcoin Core
+------------
+- [Huge wallets make Bitcoin Core unusable](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-August/020878.html) by micaroni
+- [Stale Block Fingerprinting](https://github.com/bitcoin/bitcoin/pull/24571) by dergoegge
+
+Lightning
+---------
+- mempool.space launches a [Lightning Explorer](https://mempool.space/lightning)
+- [Rapid Gossip Sync](https://lightningdevkit.org/blog/announcing-rapid-gossip-sync/) by Arik Sosman
+- [Lightning Balance Discovery Attack Mitigation](https://www.gijsvandam.nl/research/) by Gijs van Dam
+- New (book on Channel Jamming Attacks and Mitigations)[https://jamming-dev.github.io/book/] by Antoine Riard and Gleb Naumenko
+
+Privacy
+-------
+- [Tornado Cash Sanctions](https://home.treasury.gov/news/press-releases/jy0916) by the U.S. Treasury's Office of Foreign Assets Control (OFAC)
+
+Wallets
+-------
+- [Standardize Import/Export format for wallet labels](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-August/020887.html) by Craig Raw
+
+
+Misc
+----
+- [Taproot adoption graphs](https://txstats.com/dashboard/db/taproot-statistics?orgId=1)
+- [Perpetual "announcement free" DLCs with BLS signatures](https://mailmanlists.org/pipermail/dlc-dev/2022-August/000149.html) by Lloyd Fournier
+- [Fake malicious dependencies](https://twitter.com/stephenlacy/status/1554697077430505473)
+- [Fedimint development update](https://blog.blockstream.com/fedimint-update/) by Blockstream

--- a/content/socratic-1.md
+++ b/content/socratic-1.md
@@ -1,7 +1,0 @@
-+++
-title = "Socratic Seminar 1"
-date = 2022-09-08
-aliases = ["socratic/2022/09/08/socratic-1.html"]
-+++
-
-# Coming Soon

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,9 +1,4 @@
 {% extends "index.html" %} {% block content %}
-<p>
-  We are incredibly excited to revive Boston's BitDevs meetup! It's been over
-  2.5 years since our last meetup, and we cannot wait to see you in person this
-  Thursday.
-</p>
 
 <p>
   Boston BitDevs is a Bitcoin-focused, more technical meetup. Like all worldwide
@@ -15,6 +10,9 @@
   is the event for you! Whether you're a long-time Bitcoiner looking to
   participate in the discussion, or a new Bitcoiner hoping to soak up technical
   information like a sponge, all are welcome.
+</p>
+<p>
+  The reading lists for Socratic Seminars 1-8 can be found in the <a href="https://www.meetup.com/boston-bitdevs/events/past/" target="_blank">past events</a> section of the Meetup page.
 </p>
 
 <h2>Socratic Seminars</h2>


### PR DESCRIPTION
- Add reading list for Socratic Seminar number 9
- README: add SF BitDevs
- README: add instructions for running this repo locally
- `home.html`: remove wording specific to meetup number 9 since that stuff has been moved to the Socratic Seminar number 9 page, and is also on the Meetup event page. Also explain where the content for seminars 1-8 is. 

Few requests to go along with this PR:

- Can you rename the repo to `bostonbitdevs`? I see it referenced in `templates/index.html` and it matches the new domain name.
- Can you turn on issues for this repo? Similar to SF (see the [preamble](https://sfbitcoindevs.org/socratic-29/) for an example), I'd like users to be able to suggest topics by creating a new issue (see line 15 of `socratic-09.md`)